### PR TITLE
Fix error 403 on login

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ git clone "https://github.com/miikasda/gols.git"
 
 ### 2. Install dependencies:
 ```
-pip install bs4
+pip install beautifulsoup4 cloudscraper
 ```
 
 ### 3. Edit JSON data:

--- a/gols.py
+++ b/gols.py
@@ -3,7 +3,7 @@
 import os
 import re
 
-import requests
+import cloudscraper
 from bs4 import BeautifulSoup
 
 import json
@@ -75,8 +75,8 @@ def login(username, password):
         'embed': 'false'
     }
 
-    # begin session with headers because, requests client isn't an option, dunno if Icewasel is still banned...
-    s = requests.session()
+    # Use cloudscraper to get rid of error 403
+    s = cloudscraper.create_scraper()
     s.headers.update(headers)
     # we need the cookies and csrf token from the login page before we can post the user/pass
     url_gc_login = 'https://sso.garmin.com/sso/signin'


### PR DESCRIPTION
On some devices (e.g. mobile phones running Sailfish OS) login was blocked by Cloudfare with error 403. Fix uses cloudscraper to bypass it.